### PR TITLE
Add Luau callbacks for memory allocation and debug hooks

### DIFF
--- a/ffi/lua.go
+++ b/ffi/lua.go
@@ -893,19 +893,20 @@ type LuaCallbacks struct {
 func Callbacks(L *LuaState) *LuaCallbacks {
 	ccallbacks := C.lua_callbacks(L)
 
-	// sorry
 	return &LuaCallbacks{
 		Userdata:            ccallbacks.userdata,
 		Interrupt:           *(*func(L *LuaState, gc int32))(unsafe.Pointer(ccallbacks.interrupt)),
 		Panic:               *(*func(L *LuaState, errcode int32))(unsafe.Pointer(ccallbacks.panic)),
 		UserThread:          *(*func(LP *LuaState, L *LuaState))(unsafe.Pointer(ccallbacks.userthread)),
-		UserAtom:            *(*func(s string, l uint64))(unsafe.Pointer(ccallbacks.useratom)),
+		UserAtom:            *(*func(s string, l uint64) int16)(unsafe.Pointer(ccallbacks.useratom)),
 		DebugBreak:          *(*func(L *LuaState, ar *LuaDebug))(unsafe.Pointer(ccallbacks.debugbreak)),
 		DebugStep:           *(*func(L *LuaState, ar *LuaDebug))(unsafe.Pointer(ccallbacks.debugstep)),
-		DebugInterrupt:      *(*func(L *LuaState, ar *LuaDebug))(unsafe.Pointer(ccallbacks.debugstep)),
-		DebugProtectedError: *(*func(L *LuaState))(unsafe.Pointer(ccallbacks.debugstep)),
+		DebugInterrupt:      *(*func(L *LuaState, ar *LuaDebug))(unsafe.Pointer(ccallbacks.debuginterrupt)),
+		DebugProtectedError: *(*func(L *LuaState))(unsafe.Pointer(ccallbacks.debugprotectederror)),
+		OnAllocate:          *(*func(L *LuaState, osize uint64, nsize uint64))(unsafe.Pointer(ccallbacks.onallocate)),
 	}
 }
+
 
 func ToNumber(L *LuaState, i int32) LuaNumber {
 	return ToNumberX(L, i, new(bool))


### PR DESCRIPTION
From [lua.h](https://github.com/luau-lang/luau/blob/c51743268bcbe5c5af1bd78bcacaefe7f6fe3391/VM/include/lua.h#L446)

- Added OnAllocate callback to LuaCallbacks struct
- Fixed callback function signatures for UserAtom, DebugInterrupt, and DebugProtectedError
- Updated Callbacks function to correctly map additional debug and allocation callbacks from Luau